### PR TITLE
Sorted and uniq

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/KSpaceer/itertools"
 	"math"
 	"slices"
+	"strings"
 	"sync"
 	"unicode"
 )
@@ -515,6 +516,22 @@ func ExampleUniq() {
 	// 3
 	// 4
 	// 5
+}
+
+func ExampleUniqFunc() {
+	words := []string{"Hello", "HELLO", "World", "HeLlO", "world", "HEllO", "WoRlD"}
+
+	iter := itertools.UniqFunc(
+		itertools.NewSliceIterator(words),
+		strings.ToLower,
+	)
+
+	for iter.Next() {
+		fmt.Println(iter.Elem())
+	}
+	// Output:
+	// Hello
+	// World
 }
 
 func ExampleSorted() {

--- a/example_test.go
+++ b/example_test.go
@@ -501,6 +501,41 @@ func ExampleCycle() {
 	// 1
 }
 
+func ExampleUniq() {
+	s := []int{1, 2, 3, 3, 2, 4, 2, 5, 4, 5, 1}
+
+	iter := itertools.Uniq(itertools.NewSliceIterator(s))
+
+	for iter.Next() {
+		fmt.Println(iter.Elem())
+	}
+	// Output:
+	// 1
+	// 2
+	// 3
+	// 4
+	// 5
+}
+
+func ExampleSorted() {
+	s := []int{5, 8, 6, 4, 3, 7, 2, 1}
+
+	iter := itertools.Sorted(itertools.NewSliceIterator(s))
+
+	for iter.Next() {
+		fmt.Println(iter.Elem())
+	}
+	// Output:
+	// 1
+	// 2
+	// 3
+	// 4
+	// 5
+	// 6
+	// 7
+	// 8
+}
+
 func ExampleNewSliceIterator() {
 	s := []int{1, 2, 3, 4, 5}
 

--- a/example_test.go
+++ b/example_test.go
@@ -289,6 +289,34 @@ func ExampleIterator_Max() {
 	// Oldest person: John (age 42)
 }
 
+func ExampleIterator_SortedBy() {
+	type Person struct {
+		Name string
+		Age  uint
+	}
+
+	people := []Person{
+		{"Bob", 31},
+		{"John", 42},
+		{"Michael", 17},
+		{"Jenny", 26},
+	}
+
+	iter := itertools.NewSliceIterator(people).SortedBy(func(a Person, b Person) int {
+		return cmp.Compare(a.Age, b.Age)
+	})
+
+	for iter.Next() {
+		person := iter.Elem()
+		fmt.Printf("Name: %-10s Age: %d\n", person.Name, person.Age)
+	}
+	// Output:
+	// Name: Michael    Age: 17
+	// Name: Jenny      Age: 26
+	// Name: Bob        Age: 31
+	// Name: John       Age: 42
+}
+
 func ExampleChain() {
 	iter1 := itertools.NewSliceIterator([]byte("Hello"))
 

--- a/iterator.go
+++ b/iterator.go
@@ -1,5 +1,7 @@
 package itertools
 
+import "slices"
+
 // Iterator is used to process all elements of some collection
 // or sequence. Iterator contains methods to access the elements
 // and to process or aggregate them in many ways.
@@ -199,4 +201,16 @@ func (i *Iterator[T]) Max(f func(T, T) int) T {
 		}
 	}
 	return maxValue
+}
+
+// SortedBy returns new iterator yielding elements of source iterator in sorted order.
+// Sort order is defined by cmp.
+// Comparison function cmp returns next results:
+//   - -1: if the first argument is less than second one
+//   - 0: if two arguments are equal
+//   - 1: if the first argument is greater than second one
+func (i *Iterator[T]) SortedBy(cmp func(T, T) int, opts ...AllocationOption) *Iterator[T] {
+	values := i.Collect(opts...)
+	slices.SortFunc(values, cmp)
+	return NewSliceIterator(values)
 }

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"fmt"
 	"github.com/KSpaceer/itertools"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -487,6 +488,44 @@ func TestFibonacciIterator(t *testing.T) {
 				result := itertools.New(fibonacciYielder(fibonacciLimit)).Max(tc.f)
 				if tc.expected != result {
 					t.Errorf("expected %d as max value, but got %d", tc.expected, result)
+				}
+			})
+		}
+	})
+
+	t.Run("sorted by", func(t *testing.T) {
+		type tcase struct {
+			name     string
+			f        func(int, int) int
+			expected []int
+		}
+
+		tcases := []tcase{
+			{
+				name:     "asc",
+				f:        cmp.Compare[int],
+				expected: collectedValues,
+			},
+			{
+				name: "desc",
+				f: func(a int, b int) int {
+					return cmp.Compare(b, a)
+				},
+				expected: func() []int {
+					s := slices.Clone(collectedValues)
+					slices.Reverse(s)
+					return s
+				}(),
+			},
+		}
+
+		for _, tc := range tcases {
+			tc := tc
+			t.Run(tc.name, func(t *testing.T) {
+				iter := itertools.New(fibonacciYielder(fibonacciLimit)).SortedBy(tc.f)
+				result := iter.Collect()
+				if !sliceEqual(tc.expected, result) {
+					t.Errorf("expected %v, got %v", tc.expected, result)
 				}
 			})
 		}

--- a/iterfuncs.go
+++ b/iterfuncs.go
@@ -3,6 +3,7 @@ package itertools
 import (
 	"cmp"
 	"golang.org/x/exp/constraints"
+	"slices"
 )
 
 // Chain chains iterators, returning resulting chained iterator.
@@ -191,4 +192,38 @@ func Cycle[T any](i *Iterator[T], opts ...AllocationOption) *Iterator[T] {
 			return zero, false
 		}
 	})
+}
+
+// Uniq creates new iterator that yields unique element of source iterator.
+// Guaranteeing elements' uniqueness requires space complexity of O(n).
+func Uniq[T comparable](i *Iterator[T], opts ...AllocationOption) *Iterator[T] {
+	var (
+		options allocOptions
+		zero    T
+	)
+	for _, opt := range opts {
+		opt(&options)
+	}
+	metValues := make(map[T]struct{}, options.preallocSize)
+	return New(func() (T, bool) {
+		for {
+			v, ok := i.f()
+			if !ok {
+				return zero, false
+			}
+			if _, met := metValues[v]; !met {
+				metValues[v] = struct{}{}
+				return v, true
+			}
+		}
+	})
+}
+
+// Sorted creates new iterator that yields elements of source iterator in ascending order.
+// Creating of the iterator requires time complexity equal to that of slices.Sort
+// and space complexity of O(n).
+func Sorted[T cmp.Ordered](i *Iterator[T], opts ...AllocationOption) *Iterator[T] {
+	values := i.Collect(opts...)
+	slices.Sort(values)
+	return NewSliceIterator(values)
 }

--- a/iterfuncs_test.go
+++ b/iterfuncs_test.go
@@ -300,6 +300,23 @@ func TestFibonacciIterator_Iterfuncs(t *testing.T) {
 		}
 	})
 
+	t.Run("uniq func", func(t *testing.T) {
+		uniq := func(v int) int { return v % 10 }
+
+		i := itertools.UniqFunc(
+			itertools.New(fibonacciYielder(fibonacciLimit)),
+			uniq,
+		)
+
+		result := i.Collect()
+
+		expected := []int{0, 1, 2, 3, 5, 8, 34, 89}
+
+		if !sliceEqual(expected, result) {
+			t.Errorf("expected %v, got %v", expected, result)
+		}
+	})
+
 	t.Run("sorted for sorted sequence", func(t *testing.T) {
 		i := itertools.Sorted(
 			itertools.New(fibonacciYielder(fibonacciLimit)),

--- a/iterfuncs_test.go
+++ b/iterfuncs_test.go
@@ -306,6 +306,7 @@ func TestFibonacciIterator_Iterfuncs(t *testing.T) {
 		i := itertools.UniqFunc(
 			itertools.New(fibonacciYielder(fibonacciLimit)),
 			uniq,
+			itertools.WithPrealloc(len(collectedValues)),
 		)
 
 		result := i.Collect()

--- a/iterfuncs_test.go
+++ b/iterfuncs_test.go
@@ -2,6 +2,7 @@ package itertools_test
 
 import (
 	"github.com/KSpaceer/itertools"
+	"math/rand"
 	"slices"
 	"strconv"
 	"testing"
@@ -279,6 +280,52 @@ func TestFibonacciIterator_Iterfuncs(t *testing.T) {
 
 		if i.Next() {
 			t.Errorf("did not expect elements in empty cycle iterator; elem: %d", i.Elem())
+		}
+	})
+
+	t.Run("uniq", func(t *testing.T) {
+		i := itertools.Uniq(
+			itertools.New(fibonacciYielder(fibonacciLimit)),
+			itertools.WithPrealloc(len(collectedValues)-1),
+		)
+
+		result := i.Collect()
+
+		expected := make([]int, len(collectedValues))
+		copy(expected, collectedValues)
+		expected = slices.Compact(expected)
+
+		if !sliceEqual(expected, result) {
+			t.Errorf("expected %v, got %v", expected, result)
+		}
+	})
+
+	t.Run("sorted for sorted sequence", func(t *testing.T) {
+		i := itertools.Sorted(
+			itertools.New(fibonacciYielder(fibonacciLimit)),
+			itertools.WithPrealloc(len(collectedValues)),
+		)
+
+		result := i.Collect()
+
+		if !sliceEqual(collectedValues, result) {
+			t.Errorf("expected %v, got %v", collectedValues, result)
+		}
+	})
+
+	t.Run("sorted", func(t *testing.T) {
+		chaoticValues := slices.Clone(collectedValues)
+		rand.Shuffle(len(chaoticValues), func(i, j int) {
+			chaoticValues[i], chaoticValues[j] = chaoticValues[j], chaoticValues[i]
+		})
+		chaoticFibonacci := itertools.NewSliceIterator(chaoticValues)
+
+		i := itertools.Sorted(chaoticFibonacci, itertools.WithPrealloc(len(chaoticValues)))
+
+		result := i.Collect()
+
+		if !sliceEqual(collectedValues, result) {
+			t.Errorf("expected %v, got %v", collectedValues, result)
 		}
 	})
 }


### PR DESCRIPTION
Added method for ```Iterator[T]```:
- ```SortedBy(cmp func(T, T) int, opts ...AllocationOption) *Iterator[T]``` - returns iterator yielding elements in sorted order. Order is defined by cmp function.

Added functions:
- ```Uniq(iter *Iterator[T], opts ...AllocationOption) *Iterator[T]``` - returns iterator yielding unique elements.
- ```UniqFunc(iter *Iterator[T], f func(T) U, opts ...AllocationOption) *Iterator[T]``` - returns iterator yielding unique elements. Uniqueness is defined by returned value from provided function.
- ```Sorted(iter *Iterator[T], opts ...AllocationOption) *Iterator[T]``` - returns iterator yielding elements in sorted order.